### PR TITLE
moved comment class into models package for reuse in subsequent steps

### DIFF
--- a/src/main/scala/adc/tutorial/akka/streams/model/Comment.scala
+++ b/src/main/scala/adc/tutorial/akka/streams/model/Comment.scala
@@ -1,8 +1,8 @@
-package adc.tutorial.akka.streams.step6
+package adc.tutorial.akka.streams.model
 
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{JsPath, Reads, Writes}
 import play.api.libs.json.Reads._
+import play.api.libs.json.{JsPath, Reads, Writes}
 
 case class Comment(postId: Int
                    , id: Int

--- a/src/main/scala/adc/tutorial/akka/streams/step6/CommentEmitter6.scala
+++ b/src/main/scala/adc/tutorial/akka/streams/step6/CommentEmitter6.scala
@@ -1,4 +1,5 @@
 package adc.tutorial.akka.streams.step6
+import adc.tutorial.akka.streams.model.Comment
 import adc.tutorial.akka.streams.step5.SourceActor5
 import adc.tutorial.akka.streams.{fileSink, peekMatValue}
 import akka.Done

--- a/src/main/scala/adc/tutorial/akka/streams/step6/SourceActor6.scala
+++ b/src/main/scala/adc/tutorial/akka/streams/step6/SourceActor6.scala
@@ -1,7 +1,7 @@
 package adc.tutorial.akka.streams.step6
 
+import adc.tutorial.akka.streams.model.Comment
 import play.api.libs.json.Json
-
 import akka.actor.{Actor, ActorLogging, Props}
 import akka.pattern.pipe
 import akka.stream.QueueOfferResult.{Dropped, Enqueued, Failure, QueueClosed}

--- a/src/test/scala/adc/tutorial/akka/streams/step6/CommentEmitter6Spec.scala
+++ b/src/test/scala/adc/tutorial/akka/streams/step6/CommentEmitter6Spec.scala
@@ -1,5 +1,6 @@
 package adc.tutorial.akka.streams.step6
 
+import adc.tutorial.akka.streams.model.Comment
 import akka.Done
 import akka.actor.ActorSystem
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
@@ -10,7 +11,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
 
 class CommentEmitter6Spec extends FunSpec with Matchers with BeforeAndAfterAll{
-  implicit val system = ActorSystem("IntegerEmitter")
+  implicit val system = ActorSystem("CommentEmitter6")
   implicit val ec: ExecutionContext = system.dispatcher
   private val delay = 2.seconds
 

--- a/src/test/scala/adc/tutorial/akka/streams/step6/CommentSpec.scala
+++ b/src/test/scala/adc/tutorial/akka/streams/step6/CommentSpec.scala
@@ -1,5 +1,6 @@
 package adc.tutorial.akka.streams.step6
 
+import adc.tutorial.akka.streams.model.Comment
 import org.scalatest.{FunSpec, Matchers}
 import play.api.libs.json._
 


### PR DESCRIPTION
What changed:

refactored the ```Comment``` class into a ```model``` package so that it can be reused in the next steps
